### PR TITLE
When the bot is connected in 2 servers and one of them has no more music, the 'Queue is empty.' msg sent both servers.

### DIFF
--- a/DC bot tests/UnitTests/Service/Music/PlayerConnectionServiceTests.cs
+++ b/DC bot tests/UnitTests/Service/Music/PlayerConnectionServiceTests.cs
@@ -204,6 +204,51 @@ public class PlayerConnectionServiceTests
     #region TryGetAndValidateExistingPlayerAsync Tests
 
     [Fact]
+    public async Task TryJoinAndValidateRetryConnectionAttemptsAsync_ConnectionValidationSucceeds_ReturnsValid()
+    {
+        // Arrange
+        var playerMock = new Mock<ILavalinkPlayer>();
+        _validationServiceMock
+            .Setup(v => v.ValidatePlayerAsync(_audioServiceMock.Object, 111UL))
+            .ReturnsAsync(new PlayerValidationResult(true, string.Empty, playerMock.Object));
+
+        _validationServiceMock
+            .SetupSequence(v => v.ValidateConnectionAsync(It.IsAny<ILavalinkPlayer>()))
+            .ReturnsAsync(new ConnectionValidationResult(false, string.Empty, null))
+            .ReturnsAsync(new ConnectionValidationResult(true, string.Empty, playerMock.Object));
+
+        // Act
+        var result = await _service.TryJoinAndValidateAsync(_messageMock.Object, _channelMock.Object);
+
+        // Assert
+        Assert.True(result.isValid);
+        Assert.Equal(111UL, result.guildId);
+    }
+
+    [Fact]
+    public async Task TryJoinAndValidateRetryConnectionAttemptsAsync_ConnectionValidationFailsAllAttempts_ReturnsInvalid()
+    {
+        // Arrange
+        var playerMock = new Mock<ILavalinkPlayer>();
+        _validationServiceMock
+            .Setup(v => v.ValidatePlayerAsync(_audioServiceMock.Object, 111UL))
+            .ReturnsAsync(new PlayerValidationResult(true, string.Empty, playerMock.Object));
+
+        _validationServiceMock
+            .Setup(v => v.ValidateConnectionAsync(It.IsAny<ILavalinkPlayer>()))
+            .ReturnsAsync(new ConnectionValidationResult(false, ValidationErrorKeys.BotIsNotConnectedError, null));
+
+        // Act
+        var result = await _service.TryJoinAndValidateAsync(_messageMock.Object, _channelMock.Object);
+
+        // Assert
+        Assert.False(result.isValid);
+        _responseBuilderMock.Verify(
+            r => r.SendValidationErrorAsync(_messageMock.Object, ValidationErrorKeys.BotIsNotConnectedError),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task TryGetAndValidateExistingPlayerAsync_NullChannel_ReturnsInvalid()
     {
         // Act

--- a/DC bot tests/UnitTests/Service/Music/TrackEndedHandlerServiceTests.cs
+++ b/DC bot tests/UnitTests/Service/Music/TrackEndedHandlerServiceTests.cs
@@ -41,6 +41,25 @@ public class TrackEndedHandlerServiceTests
             _loggerMock.Object);
     }
 
+    #region HandleTrackEndedAsync - Do nothing when guild ID mismatch
+    [Fact]
+    public async Task HandleTrackEndedAsync_GuildIdMismatch_DoesNothing()
+    {
+        // Arrange
+        var args = CreateTrackEndedEventArgs(TrackEndReason.Finished);
+        _playerMock.Setup(p => p.GuildId).Returns(999UL); // Different guild ID
+
+        // Act
+        await _service.HandleTrackEndedAsync(_playerMock.Object, args, _textChannelMock.Object);
+
+        // Assert - should not call any services since guild ID doesn't match
+        _repeatServiceMock.Verify(r => r.IsRepeating(It.IsAny<ulong>()), Times.Never);
+        _musicQueueServiceMock.Verify(q => q.HasTracks(It.IsAny<ulong>()), Times.Never);
+        _trackNotificationServiceMock.Verify(n => n.NotifyQueueEmptyAsync(It.IsAny<IDiscordChannel>()), Times.Never);
+    }
+
+    #endregion
+
     #region HandleTrackEndedAsync - Play next from queue
 
     [Fact]

--- a/DC bot/Service/Music/MusicServices/PlayerConnectionService.cs
+++ b/DC bot/Service/Music/MusicServices/PlayerConnectionService.cs
@@ -1,4 +1,5 @@
 ﻿using DC_bot.Constants;
+using DC_bot.Helper.Validation;
 using DC_bot.Interface.Core;
 using DC_bot.Interface.Discord;
 using DC_bot.Interface.Service.Music.MusicServiceInterface;
@@ -57,10 +58,19 @@ public class PlayerConnectionService(
                 return (null, channel, guildId, false);
             }
 
-            var validationConnectionResult =
-                await validationService.ValidateConnectionAsync(connection).ConfigureAwait(false);
+            const int maxAttempts = 5;
+            const int delayMs = 200;
 
-            if (validationConnectionResult.IsValid) return (connection, channel, guildId, true);
+            ConnectionValidationResult validationConnectionResult = null!;
+            for (int attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                validationConnectionResult = await validationService.ValidateConnectionAsync(connection).ConfigureAwait(false);
+                if (validationConnectionResult.IsValid) break;
+                await Task.Delay(delayMs).ConfigureAwait(false);
+            } 
+            
+            if (validationConnectionResult is { IsValid: true })
+                return (connection, channel, guildId, true);
 
             await responseBuilder.SendValidationErrorAsync(message, validationConnectionResult.ErrorKey);
             return (null, channel, guildId, false);

--- a/DC bot/Service/Music/MusicServices/TrackEndedHandlerService.cs
+++ b/DC bot/Service/Music/MusicServices/TrackEndedHandlerService.cs
@@ -20,6 +20,9 @@ public class TrackEndedHandlerService(
     public async Task HandleTrackEndedAsync(ILavalinkPlayer player, TrackEndedEventArgs args,
         IDiscordChannel textChannel)
     {
+
+        if (player.GuildId != args.Player.GuildId) return;
+
         if (!IsFinishedOrStopped(args.Reason)) return;
 
         var guildId = textChannel.Guild.Id;


### PR DESCRIPTION
## Summary
To prevent the sendMessage event trigger for every guild, we check the guildId-s and if it's not matching we do nothing. Also we try to join the channel several times, because sometimes the bot joins later than the code try to validate the join. Because of that the bot joins the channel but the code sending error message to the text channel (Bot is not in a voice channel).

## Related Issue
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Breaking change

## How Has This Been Tested?
<!-- Describe the tests you ran and how the reviewer can verify the change. -->

## Checklist
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] I have added or updated tests where necessary
- [x] I have updated the documentation where necessary
- [x] My changes do not introduce new warnings or errors

## Screenshots / Videos
N/A

## Notes for Reviewers
N/A