### PR TITLE
VoiceState miss fixed when user typed the play command.

### DIFF
--- a/DC bot tests/UnitTests/Commands/Music/PlayCommandTests.cs
+++ b/DC bot tests/UnitTests/Commands/Music/PlayCommandTests.cs
@@ -140,7 +140,8 @@ public class PlayCommandTests
 
         await _playCommand.ExecuteAsync(_messageMock.Object);
 
-        _responseBuilderMock.Verify(r => r.SendValidationErrorAsync(_messageMock.Object, "user_not_in_voice_channel"),
+        _responseBuilderMock.Verify(
+            r => r.SendValidationErrorAsync(_messageMock.Object, ValidationErrorKeys.UserNotInVoiceChannel),
             Times.Once);
         _lavaLinkServiceMock.Verify(
             l => l.PlayAsyncQuery(It.IsAny<IDiscordChannel>(), It.IsAny<string>(), It.IsAny<IDiscordMessage>(),
@@ -176,7 +177,8 @@ public class PlayCommandTests
 
         await _playCommand.ExecuteAsync(_messageMock.Object);
 
-        _responseBuilderMock.Verify(r => r.SendValidationErrorAsync(_messageMock.Object, "user_not_in_voice_channel"),
+        _responseBuilderMock.Verify(
+            r => r.SendValidationErrorAsync(_messageMock.Object, ValidationErrorKeys.UserNotInVoiceChannel),
             Times.Once);
         _lavaLinkServiceMock.Verify(
             l => l.PlayAsyncQuery(It.IsAny<IDiscordChannel>(), It.IsAny<string>(), It.IsAny<IDiscordMessage>(),

--- a/DC bot tests/UnitTests/Wrapper/DiscordMemberWrapperTests.cs
+++ b/DC bot tests/UnitTests/Wrapper/DiscordMemberWrapperTests.cs
@@ -27,4 +27,14 @@ public class DiscordMemberWrapperTests
         var wrapper = new DiscordMemberWrapper(member);
         Assert.NotNull(wrapper.Mention);
     }
+
+    [Fact]
+    public void VoiceState_WhenProvided_UsesProvidedVoiceState()
+    {
+        var member = DiscordEntityFactory.CreateMember(id: 99ul);
+        var voiceState = DiscordEntityFactory.CreateVoiceState(channelId: 123ul);
+        var wrapper = new DiscordMemberWrapper(member, voiceState);
+
+        Assert.Equal(voiceState, wrapper.VoiceState.ToDiscordVoiceState());
+    }
 }

--- a/DC bot/Commands/Music/PlayCommand.cs
+++ b/DC bot/Commands/Music/PlayCommand.cs
@@ -34,7 +34,7 @@ public class PlayCommand(
         var voiceChannel = validationResult.Member?.VoiceState?.Channel;
         if (voiceChannel is null)
         {
-            await responseBuilder.SendValidationErrorAsync(message, "user_not_in_voice_channel");
+            await responseBuilder.SendValidationErrorAsync(message, ValidationErrorKeys.UserNotInVoiceChannel);
             return;
         }
 

--- a/DC bot/Wrapper/DiscordGuildWrapper.cs
+++ b/DC bot/Wrapper/DiscordGuildWrapper.cs
@@ -10,8 +10,12 @@ public class DiscordGuildWrapper(DiscordGuild discordGuild) : IDiscordGuild
 
     public async Task<IDiscordMember> GetMemberAsync(ulong id)
     {
-        var discordMember = await discordGuild.GetMemberAsync(id);
-        return new DiscordMemberWrapper(discordMember);
+        var discordMember = discordGuild.Members.TryGetValue(id, out var cachedMember)
+            ? cachedMember
+            : await discordGuild.GetMemberAsync(id);
+
+        discordGuild.VoiceStates.TryGetValue(id, out var voiceState);
+        return new DiscordMemberWrapper(discordMember, voiceState);
     }
 
     public DiscordGuild ToDiscordGuild()

--- a/DC bot/Wrapper/DiscordMemberWrapper.cs
+++ b/DC bot/Wrapper/DiscordMemberWrapper.cs
@@ -3,13 +3,13 @@ using DSharpPlus.Entities;
 
 namespace DC_bot.Wrapper;
 
-public class DiscordMemberWrapper(DiscordMember discordMember) : IDiscordMember
+public class DiscordMemberWrapper(DiscordMember discordMember, DiscordVoiceState? voiceState = null) : IDiscordMember
 {
     public ulong Id => discordMember.Id;
     public bool IsBot => discordMember.IsBot;
     public string Username => discordMember.Username;
     public string Mention => discordMember.Mention;
-    public IDiscordVoiceState VoiceState => new DiscordVoiceStateWrapper(discordMember.VoiceState);
+    public IDiscordVoiceState VoiceState => new DiscordVoiceStateWrapper(voiceState ?? discordMember.VoiceState);
 
     public DiscordMember ToDiscordMember()
     {


### PR DESCRIPTION
## Summary
Sometimes the bot after the !play command executed, the validation returned "Bot is not in vc" error. The reason was that we tried to get it from cached voiceState which returned null.

## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Breaking change

## How Has This Been Tested?
<!-- Describe the tests you ran and how the reviewer can verify the change. -->

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes locally
- [ ] I have added or updated tests where necessary
- [ ] I have updated the documentation where necessary
- [ ] My changes do not introduce new warnings or errors

## Screenshots / Videos
<!-- Add screenshots or recordings if the UI was changed. -->

## Notes for Reviewers
<!-- Add anything specific reviewers should pay attention to. -->
