### PR TITLE
Implement repeatable queue rehydration and improve music logging

### DIFF
--- a/DC bot tests/IntegrationTests/Service/Music/LavaLinkServiceIntegrationTests.cs
+++ b/DC bot tests/IntegrationTests/Service/Music/LavaLinkServiceIntegrationTests.cs
@@ -50,16 +50,14 @@ public class LavaLinkServiceIntegrationTests
     {
         var inMemoryPlaybackStateRepository = new InMemoryPlaybackStateRepository();
         var inMemoryRepeatListRepository = new InMemoryRepeatListRepository();
-        var repeatServiceLoggerMock = new Mock<ILogger<RepeatService>>();
         var currentTrackServiceLoggerMock = new Mock<ILogger<CurrentTrackService>>();
 
         _loggerMock.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
 
-        var queueService = new MusicQueueService(_inMemoryQueueRepository);
         _repeatService = new RepeatService(
             inMemoryPlaybackStateRepository,
-            inMemoryRepeatListRepository,
-            repeatServiceLoggerMock.Object);
+            inMemoryRepeatListRepository);
+        var queueService = new MusicQueueService(_inMemoryQueueRepository, inMemoryRepeatListRepository);
 
         _currentTrackService = new CurrentTrackService(inMemoryPlaybackStateRepository, currentTrackServiceLoggerMock.Object);
 

--- a/DC bot tests/UnitTests/Service/Music/MusicQueueServiceTests.cs
+++ b/DC bot tests/UnitTests/Service/Music/MusicQueueServiceTests.cs
@@ -13,11 +13,15 @@ public class MusicQueueServiceTests
     private const ulong GuildId = 12345UL;
     private const string ValidTrackIdentifier = "QAAA2QMAPFJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAgKE9mZmljaWFsIE11c2ljIFZpZGVvKQALUmljayBBc3RsZXkAAAAAAANACAALZFF3NHc5V2dYY1EAAQAraHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQEANGh0dHBzOi8vaS55dGltZy5jb20vdmkvZFF3NHc5V2dYY1EvbWF4cmVzZGVmYXVsdC5qcGcAAAd5b3V0dWJlAAAAAAAAAAA=";
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly Mock<IRepeatListRepository> _repeatListRepositoryMock = new();
     private readonly MusicQueueService _service;
 
     public MusicQueueServiceTests()
     {
-        _service = new MusicQueueService(_queueRepositoryMock.Object, Mock.Of<ILogger<MusicQueueService>>());
+        _service = new MusicQueueService(
+            _queueRepositoryMock.Object,
+            _repeatListRepositoryMock.Object,
+            Mock.Of<ILogger<MusicQueueService>>());
     }
 
     [Fact]
@@ -216,6 +220,42 @@ public class MusicQueueServiceTests
 
         Assert.Empty(result);
         _queueRepositoryMock.Verify(repository => repository.MarkSkippedAsync(1, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRepeatableQueue_WhenStoredIdsExist_ReturnsParsedTracks()
+    {
+        _repeatListRepositoryMock
+            .Setup(repository => repository.GetTrackIdentifiersAsync(GuildId, CancellationToken.None))
+            .ReturnsAsync([ValidTrackIdentifier, ValidTrackIdentifier]);
+
+        var result = await _service.GetRepeatableQueue(GuildId);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetRepeatableQueue_WhenSomeIdentifiersInvalid_SkipsInvalidAndReturnsValid()
+    {
+        _repeatListRepositoryMock
+            .Setup(repository => repository.GetTrackIdentifiersAsync(GuildId, CancellationToken.None))
+            .ReturnsAsync(["bad-identifier", ValidTrackIdentifier]);
+
+        var result = await _service.GetRepeatableQueue(GuildId);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetRepeatableQueue_WhenAllIdentifiersInvalid_ReturnsEmpty()
+    {
+        _repeatListRepositoryMock
+            .Setup(repository => repository.GetTrackIdentifiersAsync(GuildId, CancellationToken.None))
+            .ReturnsAsync(["bad-1", "bad-2"]);
+
+        var result = await _service.GetRepeatableQueue(GuildId);
+
+        Assert.Empty(result);
     }
 
     [Fact]

--- a/DC bot tests/UnitTests/Service/Music/RepeatServiceTests.cs
+++ b/DC bot tests/UnitTests/Service/Music/RepeatServiceTests.cs
@@ -2,7 +2,6 @@ using DC_bot.Interface;
 using DC_bot.Interface.Service.Persistence;
 using DC_bot.Interface.Service.Persistence.Models;
 using DC_bot.Service.Music.MusicServices;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace DC_bot_tests.UnitTests.Service.Music;
@@ -15,9 +14,7 @@ public class RepeatServiceTests
     {
         var service = new RepeatService(
             new InMemoryPlaybackStateRepository(),
-            new InMemoryRepeatListRepository(),
-            new Mock<ILogger<RepeatService>>().Object
-            );
+            new InMemoryRepeatListRepository());
         const ulong guildId = 10;
 
         await service.InitAsync(guildId);
@@ -31,9 +28,7 @@ public class RepeatServiceTests
     {
         var service = new RepeatService(
             new InMemoryPlaybackStateRepository(),
-            new InMemoryRepeatListRepository(),
-            new Mock<ILogger<RepeatService>>().Object
-            );
+            new InMemoryRepeatListRepository());
         const ulong guildId = 11;
 
         await service.InitAsync(guildId);
@@ -45,7 +40,7 @@ public class RepeatServiceTests
     [Fact]
     public async Task SetRepeating_WithoutInit_CreatesAndUpdatesState()
     {
-        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository(), new Mock<ILogger<RepeatService>>().Object);
+        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository());
         const ulong guildId = 12;
 
         await service.SetRepeatingAsync(guildId, true);
@@ -56,7 +51,7 @@ public class RepeatServiceTests
     [Fact]
     public async Task SetRepeatingList_AfterInit_UpdatesFlag()
     {
-        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository(), new Mock<ILogger<RepeatService>>().Object);
+        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository());
         const ulong guildId = 13;
 
         await service.InitAsync(guildId);
@@ -68,7 +63,7 @@ public class RepeatServiceTests
     [Fact]
     public async Task SetRepeatingList_WithoutInit_CreatesAndUpdatesState()
     {
-        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository(), new Mock<ILogger<RepeatService>>().Object);
+        var service = new RepeatService(new InMemoryPlaybackStateRepository(), new InMemoryRepeatListRepository());
         const ulong guildId = 14;
 
         await service.SetRepeatingListAsync(guildId, true);
@@ -83,8 +78,7 @@ public class RepeatServiceTests
         var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
         var service = new RepeatService(
             playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
+            repeatListRepositoryMock.Object);
         const ulong guildId = 15;
 
         await service.SetRepeatingListAsync(guildId, false);
@@ -99,8 +93,7 @@ public class RepeatServiceTests
         var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
         var service = new RepeatService(
             playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
+            repeatListRepositoryMock.Object);
         const ulong guildId = 16;
 
         var current = new Mock<ILavaLinkTrack>();
@@ -125,32 +118,10 @@ public class RepeatServiceTests
     {
         var service = new RepeatService(
             new InMemoryPlaybackStateRepository(),
-            new InMemoryRepeatListRepository(),
-            new Mock<ILogger<RepeatService>>().Object);
+            new InMemoryRepeatListRepository());
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
             service.SaveRepeatListSnapshotAsync(17UL, null, null!));
-    }
-
-    [Fact]
-    public async Task GetRepeatableQueueAsync_WhenStoredIdsExist_ReturnsParsedTracks()
-    {
-        var playbackStateRepository = new InMemoryPlaybackStateRepository();
-        var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
-        repeatListRepositoryMock
-            .Setup(r => r.GetTrackIdentifiersAsync(18UL, CancellationToken.None))
-            .ReturnsAsync([
-                "QAAA2QMAPFJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAgKE9mZmljaWFsIE11c2ljIFZpZGVvKQALUmljayBBc3RsZXkAAAAAAANACAALZFF3NHc5V2dYY1EAAQAraHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQEANGh0dHBzOi8vaS55dGltZy5jb20vdmkvZFF3NHc5V2dYY1EvbWF4cmVzZGVmYXVsdC5qcGcAAAd5b3V0dWJlAAAAAAAAAAA="
-            ]);
-
-        var service = new RepeatService(
-            playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
-
-        var queue = await service.GetRepeatableQueueAsync(18UL);
-
-        Assert.Single(queue);
     }
 
     private sealed class InMemoryPlaybackStateRepository : IPlaybackStateRepository
@@ -184,55 +155,13 @@ public class RepeatServiceTests
     }
 
     [Fact]
-    public async Task GetRepeatableQueueAsync_WhenSomeIdentifiersInvalid_SkipsInvalidAndReturnsValid()
-    {
-        var playbackStateRepository = new InMemoryPlaybackStateRepository();
-        var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
-        repeatListRepositoryMock
-            .Setup(r => r.GetTrackIdentifiersAsync(19UL, CancellationToken.None))
-            .ReturnsAsync([
-                "bad-identifier",
-                "QAAA2QMAPFJpY2sgQXN0bGV5IC0gTmV2ZXIgR29ubmEgR2l2ZSBZb3UgVXAgKE9mZmljaWFsIE11c2ljIFZpZGVvKQALUmljayBBc3RsZXkAAAAAAANACAALZFF3NHc5V2dYY1EAAQAraHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQEANGh0dHBzOi8vaS55dGltZy5jb20vdmkvZFF3NHc5V2dYY1EvbWF4cmVzZGVmYXVsdC5qcGcAAAd5b3V0dWJlAAAAAAAAAAA="
-            ]);
-
-        var service = new RepeatService(
-            playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
-
-        var result = await service.GetRepeatableQueueAsync(19UL);
-
-        Assert.Single(result);
-    }
-
-    [Fact]
-    public async Task GetRepeatableQueueAsync_WhenAllIdentifiersInvalid_ReturnsEmpty()
-    {
-        var playbackStateRepository = new InMemoryPlaybackStateRepository();
-        var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
-        repeatListRepositoryMock
-            .Setup(r => r.GetTrackIdentifiersAsync(20UL, CancellationToken.None))
-            .ReturnsAsync(["bad-1", "bad-2"]);
-
-        var service = new RepeatService(
-            playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
-
-        var result = await service.GetRepeatableQueueAsync(20UL);
-
-        Assert.Empty(result);
-    }
-
-    [Fact]
     public async Task SaveRepeatListSnapshot_WithNullCurrentTrack_PersistsOnlyQueue()
     {
         var playbackStateRepository = new InMemoryPlaybackStateRepository();
         var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
         var service = new RepeatService(
             playbackStateRepository,
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
+            repeatListRepositoryMock.Object);
 
         var queued1 = new Mock<ILavaLinkTrack>();
         queued1.Setup(t => t.ToString()).Returns("q1");
@@ -252,8 +181,7 @@ public class RepeatServiceTests
         var repeatListRepositoryMock = new Mock<IRepeatListRepository>();
         var service = new RepeatService(
             new InMemoryPlaybackStateRepository(),
-            repeatListRepositoryMock.Object,
-            new Mock<ILogger<RepeatService>>().Object);
+            repeatListRepositoryMock.Object);
 
         await service.SetRepeatingListAsync(22UL, true);
 

--- a/DC bot tests/UnitTests/Service/Music/TrackEndedHandlerServiceTests.cs
+++ b/DC bot tests/UnitTests/Service/Music/TrackEndedHandlerServiceTests.cs
@@ -187,7 +187,7 @@ public class TrackEndedHandlerServiceTests
         _repeatServiceMock.Setup(r => r.IsRepeatingAsync(GuildId)).ReturnsAsync(false);
         _musicQueueServiceMock.Setup(q => q.HasTracks(GuildId)).ReturnsAsync(false);
         _repeatServiceMock.Setup(r => r.IsRepeatingListAsync(GuildId)).ReturnsAsync(true);
-        _repeatServiceMock.Setup(r => r.GetRepeatableQueueAsync(GuildId)).ReturnsAsync(repeatableQueue);
+        _musicQueueServiceMock.Setup(q => q.GetRepeatableQueue(GuildId)).ReturnsAsync(repeatableQueue);
 
         await _service.HandleTrackEndedAsync(_playerMock.Object, args, _textChannelMock.Object);
 
@@ -216,7 +216,7 @@ public class TrackEndedHandlerServiceTests
 
         await _service.HandleTrackEndedAsync(_playerMock.Object, args, _textChannelMock.Object);
 
-        _repeatServiceMock.Verify(q => q.GetRepeatableQueueAsync(It.IsAny<ulong>()), Times.Never);
+        _musicQueueServiceMock.Verify(q => q.GetRepeatableQueue(It.IsAny<ulong>()), Times.Never);
     }
 
 
@@ -230,7 +230,7 @@ public class TrackEndedHandlerServiceTests
         _musicQueueServiceMock.SetupSequence(q => q.HasTracks(GuildId))
             .ReturnsAsync(false)
             .ReturnsAsync(false);
-        _repeatServiceMock.Setup(r => r.GetRepeatableQueueAsync(GuildId))
+        _musicQueueServiceMock.Setup(q => q.GetRepeatableQueue(GuildId))
             .ReturnsAsync(Array.Empty<ILavaLinkTrack>());
 
         await _service.HandleTrackEndedAsync(_playerMock.Object, args, _textChannelMock.Object);

--- a/DC bot/Commands/Queue/README.md
+++ b/DC bot/Commands/Queue/README.md
@@ -79,7 +79,8 @@ for (var i = trackList.Count - 1; i > 0; i--)
 
 1. Validates user
 2. Calls `ILavaLinkService.RepeatList()`
-3. Toggles queue repeat on/off
+3. When enabling, snapshots the current track plus queued tracks into repeat-list storage
+4. When playback reaches the end and repeat-list mode is still enabled, `TrackEndedHandlerService` reloads that snapshot through `IMusicQueueService.GetRepeatableQueue()` and copies it back into queue storage through `EnqueueMany()`
 
 ---
 
@@ -107,7 +108,9 @@ for (var i = trackList.Count - 1; i > 0; i--)
 - `SetQueue(guildId, queue)` - Replace entire queue
 - `Clear(guildId)` - Empty queue
 - `Enqueue(guildId, track)` - Add track
+- `EnqueueMany(guildId, tracks)` - Bulk add tracks, used when rehydrating repeat-list playback
 - `Dequeue(guildId)` - Remove and return next
+- `GetRepeatableQueue(guildId)` - Read the saved repeat-list snapshot and return parseable tracks
 
 ### ILavaLinkService
 
@@ -123,11 +126,14 @@ Queue state is persisted to:
 - **Implementation:** `Persistence/Repositories/QueueRepository.cs`
 - **State model:** queued/playing/played/skipped queue item lifecycle
 
+Repeat-list snapshots are stored separately through `IRepeatListRepository`; they are read by `MusicQueueService.GetRepeatableQueue()` and copied back into the queue through `IQueueRepository.EnqueueManyAsync`.
+
 ## Related Components
 
 - `Service/Music/MusicServices/MusicQueueService.cs` - Queue state management
-- `Service/Music/MusicServices/RepeatService.cs` - Repeat mode logic
+- `Service/Music/MusicServices/RepeatService.cs` - Repeat flags and repeat-list snapshot writes
 - `Interface/Service/Music/MusicServiceInterface/IMusicQueueService.cs` - Queue contract
 - `Interface/Service/Persistence/IQueueRepository.cs` - Queue persistence contract
+- `Interface/Service/Persistence/IRepeatListRepository.cs` - Repeat-list snapshot persistence contract
 - `Persistence/Repositories/QueueRepository.cs` - Queue persistence implementation
 

--- a/DC bot/Commands/SlashCommands/HelpSlashCommand.cs
+++ b/DC bot/Commands/SlashCommands/HelpSlashCommand.cs
@@ -10,11 +10,11 @@ public abstract class HelpSlashCommand : ApplicationCommandModule
     private const string CommandNameHelp = "help";
 
     // Property injection supported by DSharpPlus SlashCommands
-    public ILogger<PlaySlashCommand> Logger { private get; set; } = null!;
+    public ILogger<HelpSlashCommand> Logger { private get; set; } = null!;
     public IEnumerable<ICommand> Commands { private get; set; } = null!;
 
     [SlashCommand("help", "List the available commands")]
-    public async Task Help(InteractionContext ctx)
+    public Task Help(InteractionContext ctx)
     {
         Logger.CommandInvoked(CommandNameHelp);
         //await SlashCommandResponseHelper.DeferAsync(ctx);
@@ -25,5 +25,6 @@ public abstract class HelpSlashCommand : ApplicationCommandModule
         //await SlashCommandResponseHelper.EditResponseAsync(ctx, $"Available commands:\n{response}");
 
         Logger.CommandExecuted(CommandNameHelp);
+        return Task.CompletedTask;
     }
 }

--- a/DC bot/Commands/SlashCommands/PingSlashCommand.cs
+++ b/DC bot/Commands/SlashCommands/PingSlashCommand.cs
@@ -1,12 +1,22 @@
+using DC_bot.Logging;
 using DSharpPlus.SlashCommands;
+using Microsoft.Extensions.Logging;
 
 namespace DC_bot.Commands.SlashCommands;
 
 public abstract class PingSlashCommand : ApplicationCommandModule
 {
+    private const string CommandNamePing = "ping";
+
+    // Property injection supported by DSharpPlus SlashCommands
+    public ILogger<PingSlashCommand> Logger { private get; set; } = null!;
+
     [SlashCommand("ping", "Replies with Pong!")]
-    public async Task Ping(InteractionContext ctx)
+    public Task Ping(InteractionContext ctx)
     {
+        Logger.CommandInvoked(CommandNamePing);
         //await SlashCommandResponseHelper.RespondAsync(ctx, "Pong!");
+        Logger.CommandExecuted(CommandNamePing);
+        return Task.CompletedTask;
     }
 }

--- a/DC bot/Commands/SlashCommands/PlaySlashCommand.cs
+++ b/DC bot/Commands/SlashCommands/PlaySlashCommand.cs
@@ -14,7 +14,7 @@ public abstract class PlaySlashCommand : ApplicationCommandModule
     public ILogger<PlaySlashCommand> Logger { private get; set; } = null!;
 
     [SlashCommand("play", "Start playing music in the voice channel")]
-    public async Task Play(
+    public Task Play(
         InteractionContext ctx,
         [Option("query", "URL or search query")]
         string query)
@@ -51,5 +51,9 @@ public abstract class PlaySlashCommand : ApplicationCommandModule
 
          await SlashCommandResponseHelper.RespondAfterDeferAsync(ctx, "Now playing your request!");
          Logger.CommandExecuted(CommandNamePlay);*/
+
+        Logger.LogDebug("Slash play command body is currently disabled.");
+        Logger.CommandExecuted(CommandNamePlay);
+        return Task.CompletedTask;
     }
 }

--- a/DC bot/Commands/SlashCommands/TagSlashCommand.cs
+++ b/DC bot/Commands/SlashCommands/TagSlashCommand.cs
@@ -1,14 +1,22 @@
+using DC_bot.Logging;
 using DSharpPlus.SlashCommands;
+using Microsoft.Extensions.Logging;
 
 namespace DC_bot.Commands.SlashCommands;
 
 public abstract class TagSlashCommand : ApplicationCommandModule
 {
+    private const string CommandNameTag = "tag";
+
+    // Property injection supported by DSharpPlus SlashCommands
+    public ILogger<TagSlashCommand> Logger { private get; set; } = null!;
+
     [SlashCommand("tag", "You can tag someone")]
-    public async Task Tag(InteractionContext ctx,
+    public Task Tag(InteractionContext ctx,
         [Option("name", "Name of the member you want to tag.")]
         string username)
     {
+        Logger.CommandInvoked(CommandNameTag);
         /*if (!await SlashCommandResponseHelper.DeferAndRequireGuildAsync(ctx, "This command can only be used in a server."))
         {
             return;
@@ -24,5 +32,7 @@ public abstract class TagSlashCommand : ApplicationCommandModule
         }
 
         await SlashCommandResponseHelper.RespondAfterDeferAsync(ctx, $"You tagged: {member.Mention}");*/
+        Logger.CommandExecuted(CommandNameTag);
+        return Task.CompletedTask;
     }
 }

--- a/DC bot/Interface/Service/Music/MusicServiceInterface/IMusicQueueService.cs
+++ b/DC bot/Interface/Service/Music/MusicServiceInterface/IMusicQueueService.cs
@@ -11,6 +11,7 @@ public interface IMusicQueueService
     public Task<IReadOnlyCollection<ILavaLinkTrack>> ViewQueue(ulong guildId);
 
     public Task<Queue<ILavaLinkTrack>> GetQueue(ulong guildId);
+    Task<IReadOnlyCollection<ILavaLinkTrack>> GetRepeatableQueue(ulong guildId);
 
     public Task SetQueue(ulong guildId, Queue<ILavaLinkTrack> shuffledQueue);
     Task ClearQueue(ulong guildId);

--- a/DC bot/Interface/Service/Music/MusicServiceInterface/IRepeatService.cs
+++ b/DC bot/Interface/Service/Music/MusicServiceInterface/IRepeatService.cs
@@ -8,5 +8,4 @@ public interface IRepeatService
     Task<bool> IsRepeatingListAsync(ulong guildId);
     Task SetRepeatingListAsync(ulong guildId, bool value);
     Task SaveRepeatListSnapshotAsync(ulong guildId, ILavaLinkTrack? currentTrack, IReadOnlyCollection<ILavaLinkTrack> queuedTracks);
-    Task<IReadOnlyCollection<ILavaLinkTrack>> GetRepeatableQueueAsync(ulong guildId);
 }

--- a/DC bot/Interface/Service/Music/MusicServiceInterface/README.md
+++ b/DC bot/Interface/Service/Music/MusicServiceInterface/README.md
@@ -10,12 +10,12 @@ These interfaces split music domain responsibilities into focused contracts.
 
 - `ICurrentTrackService.cs` - Current track management
 - `ILavalinkNodeConnectionService.cs` - Lavalink node lifecycle connection
-- `IMusicQueueService.cs` - Queue operations
+- `IMusicQueueService.cs` - Queue operations, including repeat-list snapshot rehydration
 - `IPlaybackControlService.cs` - Pause, resume, skip, and leave control operations
 - `IPlaybackEventHandlerService.cs` - Playback event handling
 - `IPlaybackRequestService.cs` - Play request orchestration for URL/query input
 - `IPlayerConnectionService.cs` - Player connection management
-- `IRepeatService.cs` - Repeat mode logic
+- `IRepeatService.cs` - Repeat mode flags and repeat-list snapshot writes
 - `ITrackEndedHandlerService.cs` - Track end event handling
 - `ITrackFormatterService.cs` - Track formatting for display
 - `ITrackNotificationService.cs` - Track notification messages

--- a/DC bot/Interface/Service/Persistence/README.md
+++ b/DC bot/Interface/Service/Persistence/README.md
@@ -7,7 +7,7 @@ This folder contains persistence contracts used by the service layer.
 - `IGuildDataRepository` - guild premium state operations
 - `IPlaybackStateRepository` - current track and repeat flags
 - `IQueueRepository` - queue item lifecycle and ordering
-- `IRepeatListRepository` - repeat-list persistence
+- `IRepeatListRepository` - repeat-list snapshot persistence used for saving repeat-list mode state and rehydrating queue playback
 
 ## Models
 

--- a/DC bot/Persistence/Repositories/README.md
+++ b/DC bot/Persistence/Repositories/README.md
@@ -50,7 +50,7 @@ Implements `IRepeatListRepository`.
 
 Responsibilities:
 
-- read repeat-list track identifiers
+- read repeat-list track identifiers for `MusicQueueService.GetRepeatableQueue()`
 - replace repeat list transactionally
 - clear repeat list
 

--- a/DC bot/README.md
+++ b/DC bot/README.md
@@ -437,8 +437,8 @@ YANDEX_MUSIC_ACCESS_TOKEN=
 #### All 12 Music Services
 
 - `LavaLinkService` - Playback orchestration
-- `MusicQueueService` - Queue management
-- `RepeatService` - Repeat logic
+- `MusicQueueService` - Queue management and repeat-list snapshot rehydration
+- `RepeatService` - Repeat flags and repeat-list snapshot writes
 - `CurrentTrackService` - Track state
 - `TrackNotificationService` - Notifications
 - `TrackFormatterService` - Formatting

--- a/DC bot/Service/Music/LavaLinkService.cs
+++ b/DC bot/Service/Music/LavaLinkService.cs
@@ -32,6 +32,7 @@ public class LavaLinkService(
     public async Task Init(ulong guildId)
     {
         await repeatService.InitAsync(guildId);
+        logger.LogDebug("Music services initialized for guild {GuildId}.", guildId);
     }
 
     public async Task ConnectAsync()
@@ -81,7 +82,11 @@ public class LavaLinkService(
         playbackEventHandlerService.RegisterPlaybackFinishedHandler(guildId, connection, textChannel);
 
         var nextTrack = await musicQueueService.Dequeue(guildId);
-        if (nextTrack is null) return;
+        if (nextTrack is null)
+        {
+            logger.LogDebug("StartPlayingQueue requested for guild {GuildId}, but the queue is empty.", guildId);
+            return;
+        }
 
         try
         {
@@ -97,5 +102,9 @@ public class LavaLinkService(
         }
 
         await currentTrackService.SetCurrentTrackAsync(guildId, nextTrack);
+        logger.LogInformation("Started queue playback for guild {GuildId}: {Author} - {Title}",
+            guildId,
+            nextTrack.Author,
+            nextTrack.Title);
     }
 }

--- a/DC bot/Service/Music/MusicServices/CurrentTrackService.cs
+++ b/DC bot/Service/Music/MusicServices/CurrentTrackService.cs
@@ -18,11 +18,17 @@ public class CurrentTrackService(
     {
         var state = await playbackStateRepository.GetOrCreateAsync(guildId, cancellationToken);
         if (state.CurrentTrackIdentifier is null)
+        {
+            _logger.LogDebug("No current track stored for guild {GuildId}.", guildId);
             return null;
+        }
 
         try
         {
             var track = LavalinkTrack.Parse(state.CurrentTrackIdentifier, null);
+            _logger.LogDebug("Current track loaded for guild {GuildId}. QueueItemId: {QueueItemId}",
+                guildId,
+                state.QueueItemId);
             return new LavaLinkTrackWrapper(track)
             {
                 QueueItemId = state.QueueItemId
@@ -46,6 +52,15 @@ public class CurrentTrackService(
         }
         
         await playbackStateRepository.SetCurrentTrackAsync(guildId, identifier, queueItemId, cancellationToken);
+        if (track is null)
+        {
+            _logger.LogInformation("Current track cleared for guild {GuildId}.", guildId);
+            return;
+        }
+
+        _logger.LogDebug("Current track persisted for guild {GuildId}. QueueItemId: {QueueItemId}",
+            guildId,
+            queueItemId);
     }
 
     public async Task<string> GetCurrentTrackFormattedAsync(ulong guildId, CancellationToken cancellationToken = default)

--- a/DC bot/Service/Music/MusicServices/LavalinkNodeConnectionService.cs
+++ b/DC bot/Service/Music/MusicServices/LavalinkNodeConnectionService.cs
@@ -15,13 +15,21 @@ public class LavalinkNodeConnectionService(
 
     public async Task ConnectAsync()
     {
-        if (_isAudioServiceStarted) return;
+        if (_isAudioServiceStarted)
+        {
+            logger.LogDebug("Lavalink node connection requested, but audio service is already started.");
+            return;
+        }
 
         await _connectLock.WaitAsync().ConfigureAwait(false);
 
         try
         {
-            if (_isAudioServiceStarted) return;
+            if (_isAudioServiceStarted)
+            {
+                logger.LogDebug("Lavalink node connection skipped because another caller already started the audio service.");
+                return;
+            }
 
             await audioService.StartAsync().ConfigureAwait(false);
             _isAudioServiceStarted = true;

--- a/DC bot/Service/Music/MusicServices/MusicQueueService.cs
+++ b/DC bot/Service/Music/MusicServices/MusicQueueService.cs
@@ -8,7 +8,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DC_bot.Service.Music.MusicServices;
 
-public class MusicQueueService(IQueueRepository queueRepository, ILogger<MusicQueueService>? logger = null) : IMusicQueueService
+public class MusicQueueService(
+    IQueueRepository queueRepository,
+    IRepeatListRepository repeatListRepository,
+    ILogger<MusicQueueService>? logger = null) : IMusicQueueService
 {
     private const int MaxQueueSize = 100;
     private readonly ILogger<MusicQueueService> _logger = logger ?? NullLogger<MusicQueueService>.Instance;
@@ -121,6 +124,33 @@ public class MusicQueueService(IQueueRepository queueRepository, ILogger<MusicQu
 
         _logger.LogDebug("Queue snapshot created for guild {GuildId}. Track count: {TrackCount}", guildId, trackQueue.Count);
         return trackQueue;
+    }
+
+    public async Task<IReadOnlyCollection<ILavaLinkTrack>> GetRepeatableQueue(ulong guildId)
+    {
+        var trackIdentifiers = await repeatListRepository.GetTrackIdentifiersAsync(guildId);
+        var repeatableQueue = new List<ILavaLinkTrack>(trackIdentifiers.Count);
+
+        foreach (var identifier in trackIdentifiers)
+        {
+            try
+            {
+                var track = LavalinkTrack.Parse(identifier, null);
+                repeatableQueue.Add(new LavaLinkTrackWrapper(track));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Skipping unparsable repeat-list track identifier for guild {GuildId}. Identifier: {Identifier}",
+                    guildId,
+                    identifier);
+            }
+        }
+
+        _logger.LogDebug("Repeatable queue snapshot loaded for guild {GuildId}. Track count: {TrackCount}",
+            guildId,
+            repeatableQueue.Count);
+        return repeatableQueue;
     }
 
     public async Task SetQueue(ulong guildId, Queue<ILavaLinkTrack> shuffledQueue)

--- a/DC bot/Service/Music/MusicServices/PlaybackControlService.cs
+++ b/DC bot/Service/Music/MusicServices/PlaybackControlService.cs
@@ -85,6 +85,7 @@ public class PlaybackControlService(
         {
             await trackNotificationService.SendSafeAsync(channel,
                 localizationService.Get(guildId, LocalizationKeys.SkipCommandError), "SkipAsync.NoTrack");
+            logger.LogInformation("Skip requested for guild {GuildId}, but no current or queued track exists.", guildId);
             return;
         }
 
@@ -92,6 +93,7 @@ public class PlaybackControlService(
         {
             await connection.StopAsync();
             progressiveTimerService.Stop(guildId);
+            logger.LogInformation("Skip requested for guild {GuildId}. Current playback stopped.", guildId);
         }
         catch (Exception ex)
         {
@@ -112,6 +114,7 @@ public class PlaybackControlService(
             await playbackEventHandlerService.CleanupGuildAsync(guildId).ConfigureAwait(false);
             progressiveTimerService.Stop(guildId);
             await connection.DisconnectAsync().ConfigureAwait(false);
+            logger.LogInformation("Disconnected from voice channel for guild {GuildId}.", guildId);
         }
         catch (Exception ex)
         {

--- a/DC bot/Service/Music/MusicServices/PlaybackEventHandlerService.cs
+++ b/DC bot/Service/Music/MusicServices/PlaybackEventHandlerService.cs
@@ -17,7 +17,11 @@ public class PlaybackEventHandlerService(
 
     public void RegisterPlaybackFinishedHandler(ulong guildId, ILavalinkPlayer connection, IDiscordChannel textChannel)
     {
-        if (_trackEndedHandlers.ContainsKey(guildId)) return;
+        if (_trackEndedHandlers.ContainsKey(guildId))
+        {
+            logger.LogDebug("Playback finished event already registered for guild {GuildId}", guildId);
+            return;
+        }
 
         AsyncEventHandler<TrackEndedEventArgs> handler = async (_, args) =>
             await trackEndedHandlerService.HandleTrackEndedAsync(connection, args, textChannel);

--- a/DC bot/Service/Music/MusicServices/PlaybackRequestService.cs
+++ b/DC bot/Service/Music/MusicServices/PlaybackRequestService.cs
@@ -59,9 +59,21 @@ public class PlaybackRequestService(
         string loadFailureMessage,
         Action<string> logNotFound)
     {
+        logger.LogDebug(
+            "Playback request started. Guild: {GuildId}, Channel: {ChannelId}, SearchMode: {SearchMode}, Operation: {Operation}",
+            voiceStateChannel.Guild.Id,
+            voiceStateChannel.Id,
+            trackSearchMode,
+            loadOperation);
+
         var (connection, _, guildId, isValid) =
             await playerConnectionService.TryJoinAndValidateAsync(message, voiceStateChannel);
-        if (!isValid || connection == null) return;
+        if (!isValid || connection == null)
+        {
+            logger.LogInformation("Playback request aborted after failed connection validation. Guild: {GuildId}",
+                voiceStateChannel.Guild.Id);
+            return;
+        }
 
         var textChannel = message.Channel;
 
@@ -89,6 +101,9 @@ public class PlaybackRequestService(
             throw new TrackLoadException(query, "Track not found or load failed");
         }
 
+        logger.LogDebug("Playback request loaded tracks for guild {GuildId}. IsPlaylist: {IsPlaylist}",
+            guildId,
+            loadResult.IsPlaylist);
         await trackPlaybackService.PlayTheFoundMusicAsync(loadResult, connection, textChannel);
     }
 }

--- a/DC bot/Service/Music/MusicServices/PlayerConnectionService.cs
+++ b/DC bot/Service/Music/MusicServices/PlayerConnectionService.cs
@@ -24,6 +24,7 @@ public class PlayerConnectionService(
     {
         if (channel is null)
         {
+            logger.LogInformation("Join validation failed because the user is not in a voice channel.");
             await responseBuilder.SendValidationErrorAsync(message, ValidationErrorKeys.UserNotInVoiceChannel);
             return (null, null, 0, false);
         }
@@ -54,6 +55,10 @@ public class PlayerConnectionService(
 
             if (!validationPlayerResult.IsValid)
             {
+                logger.LogInformation(
+                    "Player validation failed after join attempt. Guild: {GuildId}, ErrorKey: {ErrorKey}",
+                    guildId,
+                    validationPlayerResult.ErrorKey);
                 await responseBuilder.SendValidationErrorAsync(message, validationPlayerResult.ErrorKey);
                 return (null, channel, guildId, false);
             }
@@ -70,8 +75,18 @@ public class PlayerConnectionService(
             } 
             
             if (validationConnectionResult is { IsValid: true })
+            {
+                logger.LogInformation("Joined and validated voice channel. Guild: {GuildId}, Channel: {ChannelId}",
+                    guildId,
+                    channel.Id);
                 return (connection, channel, guildId, true);
+            }
 
+            logger.LogInformation(
+                "Connection validation failed after join attempt. Guild: {GuildId}, Channel: {ChannelId}, ErrorKey: {ErrorKey}",
+                guildId,
+                channel.Id,
+                validationConnectionResult.ErrorKey);
             await responseBuilder.SendValidationErrorAsync(message, validationConnectionResult.ErrorKey);
             return (null, channel, guildId, false);
         }
@@ -99,6 +114,7 @@ public class PlayerConnectionService(
     {
         if (channel is null)
         {
+            logger.LogInformation("Existing player validation failed because the user is not in a voice channel.");
             await responseBuilder.SendValidationErrorAsync(message, ValidationErrorKeys.UserNotInVoiceChannel);
             return (null, null, 0, false);
         }
@@ -112,12 +128,17 @@ public class PlayerConnectionService(
 
             if (!validationPlayerResult.IsValid)
             {
+                logger.LogInformation(
+                    "Existing player validation failed. Guild: {GuildId}, ErrorKey: {ErrorKey}",
+                    guildId,
+                    validationPlayerResult.ErrorKey);
                 await responseBuilder.SendValidationErrorAsync(message, validationPlayerResult.ErrorKey);
                 return (null, channel, guildId, false);
             }
 
             if (validationPlayerResult.Player is null)
             {
+                logger.LogError("Existing player validation returned success without a player. Guild: {GuildId}", guildId);
                 await responseBuilder.SendValidationErrorAsync(message, ValidationErrorKeys.LavalinkError);
                 return (null, channel, guildId, false);
             }
@@ -126,8 +147,16 @@ public class PlayerConnectionService(
             var validationConnectionResult =
                 await validationService.ValidateConnectionAsync(connection).ConfigureAwait(false);
 
-            if (validationConnectionResult.IsValid) return (connection, channel, guildId, true);
+            if (validationConnectionResult.IsValid)
+            {
+                logger.LogDebug("Existing player validated for guild {GuildId}.", guildId);
+                return (connection, channel, guildId, true);
+            }
 
+            logger.LogInformation(
+                "Existing connection validation failed. Guild: {GuildId}, ErrorKey: {ErrorKey}",
+                guildId,
+                validationConnectionResult.ErrorKey);
             await responseBuilder.SendValidationErrorAsync(message, validationConnectionResult.ErrorKey);
             return (null, channel, guildId, false);
         }

--- a/DC bot/Service/Music/MusicServices/README.md
+++ b/DC bot/Service/Music/MusicServices/README.md
@@ -42,16 +42,18 @@ These services split music functionality into focused responsibilities. Each imp
 - `ViewQueue()` - View all queued tracks
 - `HasTracks()` - Check if queue has tracks
 - `GetQueue()` - Get queue snapshot
+- `GetRepeatableQueue()` - Load the saved repeat-list snapshot from `IRepeatListRepository`, parse valid track identifiers, and return tracks that can be copied back into the queue
 - `SetQueue()` - Persist reordered queue
 - `ClearQueue()` - Mark queued tracks as skipped
-- `GetRepeatableQueue()` - Declared on `IMusicQueueService`, but the current `MusicQueueService` implementation throws `NotImplementedException`; repeat-list snapshots are handled by `RepeatService`
 
 **Persistence:**
 
 - Uses `IQueueRepository` for database-backed queue operations
+- Uses `IRepeatListRepository` to read repeat-list snapshots when queue repeat needs to restart playback
 - Queue state transitions are persisted (`queued`, `playing`, `played`, `skipped`)
 - Ordering updates are handled transactionally in repository layer
 - `QueueItemId` on the dequeued `LavaLinkTrackWrapper` is later used by `TrackEndedHandlerService` to mark the item as played or skipped
+- When repeat-list playback restarts, `TrackEndedHandlerService` loads tracks through `GetRepeatableQueue()` and copies them into queue storage through `EnqueueMany()`
 
 ---
 
@@ -134,7 +136,13 @@ These services split music functionality into focused responsibilities. Each imp
 
 **Implements:** `IRepeatService`
 
-**Purpose:** Manage repeat modes (single track, queue).
+**Purpose:** Manage repeat mode flags and persist repeat-list snapshots.
+
+**Key Methods:**
+
+- `SetRepeatingAsync()` - Toggle current-track repeat
+- `SetRepeatingListAsync()` - Toggle repeat-list mode and clear the saved snapshot when disabled
+- `SaveRepeatListSnapshotAsync()` - Persist the current track plus queued tracks into `IRepeatListRepository`
 
 ---
 

--- a/DC bot/Service/Music/MusicServices/RepeatService.cs
+++ b/DC bot/Service/Music/MusicServices/RepeatService.cs
@@ -1,25 +1,30 @@
 ﻿using DC_bot.Interface;
 using DC_bot.Interface.Service.Music.MusicServiceInterface;
 using DC_bot.Interface.Service.Persistence;
-using DC_bot.Wrapper;
-using Lavalink4NET.Tracks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DC_bot.Service.Music.MusicServices;
 
 public class RepeatService(
     IPlaybackStateRepository playbackStateRepository,
-    IRepeatListRepository repeatListRepository, 
-    ILogger<RepeatService> logger) : IRepeatService
+    IRepeatListRepository repeatListRepository,
+    ILogger<RepeatService>? logger = null) : IRepeatService
 {
+    private readonly ILogger<RepeatService> _logger = logger ?? NullLogger<RepeatService>.Instance;
+
     public async Task InitAsync(ulong guildId)
     {
         await playbackStateRepository.GetOrCreateAsync(guildId);
+        _logger.LogDebug("Repeat state initialized for guild {GuildId}.", guildId);
     }
 
     public async Task<bool> IsRepeatingAsync(ulong guildId)
     {
         var state = await playbackStateRepository.GetOrCreateAsync(guildId);
+        _logger.LogDebug("Single-track repeat state queried for guild {GuildId}. Enabled: {IsRepeating}",
+            guildId,
+            state.IsRepeating);
         return state.IsRepeating;
     }
 
@@ -27,11 +32,19 @@ public class RepeatService(
     {
         var state = await playbackStateRepository.GetOrCreateAsync(guildId);
         await playbackStateRepository.SetRepeatStateAsync(guildId, value, state.IsRepeatingList);
+        _logger.LogInformation(
+            "Single-track repeat state updated for guild {GuildId}. Previous: {PreviousValue}, New: {NewValue}",
+            guildId,
+            state.IsRepeating,
+            value);
     }
 
     public async Task<bool> IsRepeatingListAsync(ulong guildId)
     {
         var state = await playbackStateRepository.GetOrCreateAsync(guildId);
+        _logger.LogDebug("Repeat-list state queried for guild {GuildId}. Enabled: {IsRepeatingList}",
+            guildId,
+            state.IsRepeatingList);
         return state.IsRepeatingList;
     }
 
@@ -39,10 +52,16 @@ public class RepeatService(
     {
         var state = await playbackStateRepository.GetOrCreateAsync(guildId);
         await playbackStateRepository.SetRepeatStateAsync(guildId, state.IsRepeating, value);
+        _logger.LogInformation(
+            "Repeat-list state updated for guild {GuildId}. Previous: {PreviousValue}, New: {NewValue}",
+            guildId,
+            state.IsRepeatingList,
+            value);
 
         if (!value)
         {
             await repeatListRepository.ClearAsync(guildId);
+            _logger.LogInformation("Repeat-list snapshot cleared for guild {GuildId}.", guildId);
         }
     }
 
@@ -62,25 +81,11 @@ public class RepeatService(
         trackIdentifiers.AddRange(queuedTracks.Select(track => track.ToString()));
 
         await repeatListRepository.ReplaceAsync(guildId, trackIdentifiers);
+        _logger.LogInformation(
+            "Repeat-list snapshot saved for guild {GuildId}. Track count: {TrackCount}, Includes current track: {IncludesCurrentTrack}",
+            guildId,
+            trackIdentifiers.Count,
+            currentTrack is not null);
     }
 
-    public async Task<IReadOnlyCollection<ILavaLinkTrack>> GetRepeatableQueueAsync(ulong guildId)
-    {
-        var trackIdentifiers = await repeatListRepository.GetTrackIdentifiersAsync(guildId);
-        var validTracks = new List<ILavaLinkTrack>();
-       foreach (var identifier in trackIdentifiers)
-        {
-            try
-            {
-                var track = LavalinkTrack.Parse(identifier, null);
-                validTracks.Add(new LavaLinkTrackWrapper(track));
-            }
-            catch (Exception ex)
-            { 
-                logger.LogError(ex, "Corrupted track identifier: {GuildId}. Identifier: {Identifier}", guildId, identifier);
-            }
-        }
-
-        return validTracks;
-    }
 }

--- a/DC bot/Service/Music/MusicServices/TrackEndedHandlerService.cs
+++ b/DC bot/Service/Music/MusicServices/TrackEndedHandlerService.cs
@@ -85,7 +85,7 @@ public class TrackEndedHandlerService(
 
         if (await musicQueueService.HasTracks(guildId)) return false;
 
-        var repeatableQueue = await repeatService.GetRepeatableQueueAsync(guildId);
+        var repeatableQueue = await musicQueueService.GetRepeatableQueue(guildId);
         if (repeatableQueue.Count == 0)
         {
             return false;

--- a/DC bot/Service/Music/MusicServices/TrackPlaybackService.cs
+++ b/DC bot/Service/Music/MusicServices/TrackPlaybackService.cs
@@ -22,6 +22,10 @@ public class TrackPlaybackService(
     {
         var musicTracks = searchQuery.IsPlaylist ? searchQuery.Tracks.ToList() : [searchQuery.Track!];
         var guildId = textChannel.Guild.Id;
+        logger.LogDebug("Playback request resolved for guild {GuildId}. IsPlaylist: {IsPlaylist}, TrackCount: {TrackCount}",
+            guildId,
+            searchQuery.IsPlaylist,
+            musicTracks.Count);
 
         if (searchQuery.IsPlaylist)
         {
@@ -36,7 +40,11 @@ public class TrackPlaybackService(
         {
             var nextTrack = await musicQueueService.Dequeue(guildId);
 
-            if (nextTrack == null) return;
+            if (nextTrack == null)
+            {
+                logger.LogWarning("Playback request for guild {GuildId} enqueued tracks, but no track could be dequeued.", guildId);
+                return;
+            }
 
             try
             {
@@ -54,6 +62,10 @@ public class TrackPlaybackService(
             }
 
             await currentTrackService.SetCurrentTrackAsync(guildId, nextTrack);
+            logger.LogInformation("Started playback from queue for guild {GuildId}: {Author} - {Title}",
+                guildId,
+                nextTrack.Author,
+                nextTrack.Title);
             return;
         }
 
@@ -82,7 +94,11 @@ public class TrackPlaybackService(
     public async Task TryPlayNextTrackAsync(ILavalinkPlayer player, IDiscordChannel textChannel, ulong guildId)
     {
         var nextTrack = await musicQueueService.Dequeue(guildId);
-        if (nextTrack is null) return;
+        if (nextTrack is null)
+        {
+            logger.LogDebug("No queued track available for guild {GuildId}.", guildId);
+            return;
+        }
 
         try
         {
@@ -90,6 +106,10 @@ public class TrackPlaybackService(
             await trackNotificationService.NotifyNowPlayingAsync(textChannel, nextTrack,
                 nextTrack.StartPosition ?? TimeSpan.Zero, nextTrack.Duration);
             await currentTrackService.SetCurrentTrackAsync(guildId, nextTrack);
+            logger.LogInformation("Started next queued track for guild {GuildId}: {Author} - {Title}",
+                guildId,
+                nextTrack.Author,
+                nextTrack.Title);
         }
         catch (Exception ex)
         {

--- a/DC bot/Service/Music/README.md
+++ b/DC bot/Service/Music/README.md
@@ -35,7 +35,7 @@ This folder contains music playback and queue management services.
 - Uses `IPlayerConnectionService` for voice channel management
 - Uses `ITrackPlaybackService` for queue track playback
 - Uses `IPlaybackEventHandlerService` for event handling
-- Uses `IMusicQueueService` for queue management
+- Uses `IMusicQueueService` for queue management and repeat-list queue rehydration
 
 ---
 


### PR DESCRIPTION
## Summary
- Implemented `IMusicQueueService.GetRepeatableQueue` using repeat-list persistence.
- Moved repeat-list queue reconstruction into `MusicQueueService`, while keeping `RepeatService` focused on repeat flags and snapshot writes.
- Updated track-ended repeat-list playback to reload the saved snapshot and copy it back into the queue through `EnqueueMany`.
- Added missing logging around repeat state, current-track persistence, player connection validation, playback flow, skip/leave actions, and slash command stubs.
- Updated tests and README documentation for the new repeat-list queue flow.

## Related Issue
- Repeat-list playback now restores the saved database snapshot into the queue correctly.
- `TrackEndedHandlerService` no longer relies on `RepeatService` to rebuild queue tracks.
- Previously silent runtime branches now produce useful logs for validation failures, empty queues, connection reuse, playback starts, and state changes.
- Removed new logging-related build warnings and fixed slash command stub logging coverage.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Breaking change

## How Has This Been Tested?
<!-- Describe the tests you ran and how the reviewer can verify the change. -->

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes locally
- [ ] I have added or updated tests where necessary
- [ ] I have updated the documentation where necessary
- [ ] My changes do not introduce new warnings or errors

## Screenshots / Videos
<!-- Add screenshots or recordings if the UI was changed. -->

## Notes for Reviewers
<!-- Add anything specific reviewers should pay attention to. -->
